### PR TITLE
chore: release 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ import { AuthProvider, AuthService } from 'react-oauth2-pkce'
 import { Routes } from './Routes';
 
 const authService = new AuthService({
-  clientId: process.env.REACT_APP_CLIENT_ID || 'CHANGEME',
-  location: window.location,
-  provider: process.env.REACT_APP_PROVIDER || 'https://sandbox.auth.ap-southeast-2.amazoncognito.com/oauth2',
-  redirectUri: process.env.REACT_APP_REDIRECT_URI || window.location.origin,
-  scopes: ['openid', 'profile']
+  `${process.env.REACT_APP_CLIENT_ID}`: {
+    clientId: process.env.REACT_APP_CLIENT_ID || 'CHANGEME',
+    location: window.location,
+    provider: process.env.REACT_APP_PROVIDER || 'https://sandbox.auth.ap-southeast-2.amazoncognito.com/oauth2',
+    redirectUri: process.env.REACT_APP_REDIRECT_URI || window.location.origin,
+    scopes: ['openid', 'profile'],
+    state: process.env.REACT_APP_CLIENT_ID
+  } // Use the clientID as the key for the auth provider!
 });
 
 const App = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-fintech/react-oauth2-pkce",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Authenticate against generic OAuth2 using PKCE",
   "author": "Gardner Bickford <gardner@bickford.nz>",
   "license": "MIT",


### PR DESCRIPTION
BREAKING CHANGE: AuthService now expects an object whose keys
correspond to the clientId of the auth provider.
This allows you to configure more than one auth provider with
AuthService.